### PR TITLE
Fix enemy speed scaling and debug overlay display

### DIFF
--- a/src/game/Constants.js
+++ b/src/game/Constants.js
@@ -28,25 +28,23 @@ export const DIR_DELTAS = {
 export const MAX_SUBSTEPS = 4;
 export function computeEnemySpeed(level) {
   // Adjust enemy speed to scale by a fixed percentage each round.
-  // Previously, the enemy speed increased linearly with the level:
-  //    base = 0.30 + (level - 1) * (0.20 / 9);
-  // which equated to a fixed additive increase each level.  This caused the
-  // enemy to remain roughly 60% of the player's speed for most of the game,
-  // rather than accelerating by a constant percentage per level.
+  // Previously, the enemy speed increased linearly with the level which
+  // equated to a fixed additive increase each level.  This caused the enemy
+  // to remain roughly 60% of the player's speed for most of the game, rather
+  // than accelerating by a constant percentage per level.
   //
   // To ensure the enemy speed scales by a constant *percentage* each round,
-  // use exponential interpolation between the starting ratio (60% of the
-  // player's speed) and a final ratio (100% of the player's speed) at the
-  // maximum level.  Each level multiplies the ratio by a constant factor,
-  // resulting in perceptible acceleration as levels increase.
+  // multiply the starting ratio (60% of the player's speed) by a growth
+  // factor of 1.05 for every level beyond the first.  This yields an enemy
+  // that gains 5% additional speed each level while remaining capped at the
+  // player's base speed.
   const lvl = Math.max(1, Math.min(MAX_LEVEL, level | 0));
-  // On level 1 the enemy moves at 60% of the player's base speed.
-  // Increase this ratio by a fixed 5 percentage points on each subsequent level,
-  // capping at 100% of the player's speed.  This means the enemy will be at
-  // 65% on level 2, 70% on level 3, … up to parity with the player by level 9.
   const startRatio = 0.60;
-  const increment  = 0.05;
-  // Compute the ratio for the given level.  Clamp to a maximum of 1.0.
-  const ratio = Math.min(1.0, startRatio + (lvl - 1) * increment);
+  const growthPerLevel = 0.05;
+  const steps = Math.max(0, lvl - 1);
+  const growthFactor = 1 + growthPerLevel;
+  // Compute the ratio for the given level.  Clamp to a maximum of 1.0 to
+  // avoid exceeding the player's speed at extremely high levels.
+  const ratio = Math.min(1.0, startRatio * Math.pow(growthFactor, steps));
   return PLAYER_BASE_SPEED * ratio;
 }

--- a/src/game/engine/step.js
+++ b/src/game/engine/step.js
@@ -28,6 +28,14 @@ function updateProgress(state, delta) {
   // acceleration reflects the new level without relying on external
   // orchestrator updates.  Should the constants service be unavailable,
   // fall back to the linear ratio computation.
+  const computeFallbackEnemySpeed = (level) => {
+    const baseRatio = 0.60;
+    const growth = 0.05;
+    const steps = Math.max(0, level - 1);
+    const ratio = Math.min(1.0, baseRatio * Math.pow(1 + growth, steps));
+    return PLAYER_BASE_SPEED * ratio;
+  };
+
   let ENEMY_SPEED = 0;
   try {
     if (C && typeof C.computeEnemySpeed === 'function') {
@@ -36,23 +44,14 @@ function updateProgress(state, delta) {
         ENEMY_SPEED = result;
       } else {
         // fall back to ratio if computeEnemySpeed returned non-finite
-        const baseRatio = 0.60;
-        const increment = 0.05;
-        const ratio = Math.min(1.0, baseRatio + (currentLevel - 1) * increment);
-        ENEMY_SPEED = PLAYER_BASE_SPEED * ratio;
+        ENEMY_SPEED = computeFallbackEnemySpeed(currentLevel);
       }
     } else {
-      // Fallback: start at 60% of the player's speed and add 5pp per level
-      const baseRatio = 0.60;
-      const increment = 0.05;
-      const ratio = Math.min(1.0, baseRatio + (currentLevel - 1) * increment);
-      ENEMY_SPEED = PLAYER_BASE_SPEED * ratio;
+      // Fallback: start at 60% of the player's speed and grow 5% per level.
+      ENEMY_SPEED = computeFallbackEnemySpeed(currentLevel);
     }
   } catch (_) {
-    const baseRatio = 0.60;
-    const increment = 0.05;
-    const ratio = Math.min(1.0, baseRatio + (currentLevel - 1) * increment);
-    ENEMY_SPEED = PLAYER_BASE_SPEED * ratio;
+    ENEMY_SPEED = computeFallbackEnemySpeed(currentLevel);
   }
   // Mirror the computed enemy speed back onto the mutable state so that
   // observers (e.g. debug overlay) can read the most recent value without

--- a/src/game/ui/detailedDebugOverlay.js
+++ b/src/game/ui/detailedDebugOverlay.js
@@ -180,17 +180,26 @@ export function initDebugOverlay({
         const lvlNum = Number(levelRaw);
         if (!Number.isNaN(lvlNum)) {
           const pSpeed = (typeof C.PLAYER_BASE_SPEED === 'number') ? C.PLAYER_BASE_SPEED : 0;
-          // If the game state exposes a numeric enemySpeed (set by the orchestrator), use it directly.
-          let eSpeedVal = 0;
-          if (typeof gs.enemySpeed === 'number' && Number.isFinite(gs.enemySpeed)) {
+          // Prefer computing the speed directly from the constants service so
+          // the overlay matches the runtime behaviour.  If that fails, fall
+          // back to any value mirrored on the mutable game state, and finally
+          // recompute locally using the known growth curve.
+          let eSpeedVal;
+          if (typeof C.computeEnemySpeed === 'function') {
+            const computed = C.computeEnemySpeed(lvlNum);
+            if (Number.isFinite(computed)) {
+              eSpeedVal = computed;
+            }
+          }
+          if (eSpeedVal == null && typeof gs.enemySpeed === 'number' && Number.isFinite(gs.enemySpeed)) {
             eSpeedVal = gs.enemySpeed;
-          } else if (typeof C.computeEnemySpeed === 'function') {
-            eSpeedVal = C.computeEnemySpeed(lvlNum) || 0;
-          } else {
-            // Fallback mirrors constants: start 60% and +5pp per level up to 100%
+          }
+          if (eSpeedVal == null) {
+            // Fallback mirrors constants: start at 60% and grow by 5% per level up to 100%.
             const baseRatio = 0.60;
-            const increment = 0.05;
-            const ratio = Math.min(1.0, baseRatio + (lvlNum - 1) * increment);
+            const growth = 0.05;
+            const steps = Math.max(0, lvlNum - 1);
+            const ratio = Math.min(1.0, baseRatio * Math.pow(1 + growth, steps));
             eSpeedVal = ratio * pSpeed;
           }
           const ratio = pSpeed > 0 ? (eSpeedVal / pSpeed) : 0;


### PR DESCRIPTION
## Summary
- update the enemy speed curve to grow by 5% per level starting from 60% of the player and cap at parity
- align engine fallbacks with the new curve so gameplay speed increases correctly at every level
- refresh the debug overlay logic to prefer the constants service and report the updated enemy speed percentage

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2f13ab9388321adff961ecb1d0f98